### PR TITLE
Set server_name and and option for setting trusted WOPI host

### DIFF
--- a/nixos/modules/services/web-apps/loolwsd/default.nix
+++ b/nixos/modules/services/web-apps/loolwsd/default.nix
@@ -22,6 +22,7 @@ let
     # should be able to avoid mismatches of package name with the corresponding locale name
     "allowed_languages" = concatMapStringsSep " " (builtins.substring 0 2) cfg.dictionaries;
   } // (optionalAttrs cfg.proxy.enable { server_name = cfg.proxy.hostname; })
+  // (optionalAttrs (cfg.trustedHost != "") { "storage.wopi.host[0]" = cfg.trustedHost; })
   // cfg.settings;
   cmdLineVal = v: if v == true then "true" else if v == false then "false" else escapeShellArg v;
 
@@ -69,6 +70,16 @@ in
         List of Hunspell dictionaries to include for spellchecking functionality.
 
         The values must be names of attributes in <varname>pkgs.hunspellDicts</varname>.
+      '';
+    };
+
+    trustedHost = mkOption {
+      type = str;
+      default = config.services.nextcloud.hostName or "";
+      defaultText = "\${config.services.nextcloud.hostName}";
+      example = "cloud.example.com";
+      description = ''
+        Regex expression matching hostnames that are trusted to use loolwsd
       '';
     };
 

--- a/nixos/modules/services/web-apps/loolwsd/default.nix
+++ b/nixos/modules/services/web-apps/loolwsd/default.nix
@@ -9,7 +9,7 @@ let
   pkg = cfg.package;
   corePkg = pkg.passthru.libreoffice;
   subdir = corePkg.pname;
-  cmdLineOpts = {
+  cmdLineOpts = with attrsets; {
     sys_template_path = "${dataDir}/systemplate";
     child_root_path = "${dataDir}/child-roots";
     file_server_root_path = "${pkg}/share/loolwsd";
@@ -21,7 +21,8 @@ let
     # LO treats allowed_languages as a list of prefixes, by taking the first two letters we
     # should be able to avoid mismatches of package name with the corresponding locale name
     "allowed_languages" = concatMapStringsSep " " (builtins.substring 0 2) cfg.dictionaries;
-  } // cfg.settings;
+  } // (optionalAttrs cfg.proxy.enable { server_name = cfg.proxy.hostname; })
+  // cfg.settings;
   cmdLineVal = v: if v == true then "true" else if v == false then "false" else escapeShellArg v;
 
   sysTemplateSetup = ./loolwsd-systemplate-setup-nixos;


### PR DESCRIPTION
###### Motivation for this change
Implement the suggestions I posted in the loolwsd init PR: 
 - set server_name if the proxy is enabled, as the loolwsd.xml says to set it if lool is behind a reverse proxy and
 - add an option to easily set the trusted WOPI host. I set this to nextcloud's hostname by default if thats set, since that will probably be what most users want.

This evaluates, but I'm still rebuilding libreoffice due to the recent changes in the package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

